### PR TITLE
fix bug of LogReport in mnist example

### DIFF
--- a/docs/source/tutorial/step2_datasets_evaluators.rst
+++ b/docs/source/tutorial/step2_datasets_evaluators.rst
@@ -99,9 +99,10 @@ many redundant lines will appear in your console.
 Therefore, it is convenient to register these extensions
 only at workers of rank zero as follows::
 
+  log_interval = chainermn.get_epoch_trigger(1, train, args.batchsize, comm)
   if comm.rank == 0:
       trainer.extend(extensions.dump_graph('main/loss'))
-      trainer.extend(extensions.LogReport())
+      trainer.extend(extensions.LogReport(trigger=log_interval))
       trainer.extend(extensions.PrintReport(
           ['epoch', 'main/loss', 'validation/main/loss',
            'main/accuracy', 'validation/main/accuracy', 'elapsed_time']))

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -91,9 +91,10 @@ def main():
 
     # Some display and output extensions are necessary only for one worker.
     # (Otherwise, there would just be repeated outputs.)
+    log_interval = chainermn.get_epoch_trigger(1, train, args.batchsize, comm)
     if comm.rank == 0:
         trainer.extend(extensions.dump_graph('main/loss'))
-        trainer.extend(extensions.LogReport())
+        trainer.extend(extensions.LogReport(trigger=log_interval))
         trainer.extend(extensions.PrintReport(
             ['epoch', 'main/loss', 'validation/main/loss',
              'main/accuracy', 'validation/main/accuracy', 'elapsed_time']))


### PR DESCRIPTION
When mnist example is run with -b 128, epoch 2 log is not output.
Its example is :

```
$ mpiexec -n 4 python examples/mnist/train_mnist.py -b 128 -g 
GPU: 0
# unit: 1000
# Minibatch-size: 128
# epoch: 20
epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy  elapsed_time
1           0.314679    0.126357              0.911149       0.96061                   3.49345       
2           0.0935955                         0.97269                                  4.91697       
3           0.0541213   0.0860978             0.985577       0.973357                  6.36811       
4           0.034525    0.0751695             0.989183       0.976068                  7.84156       
5           0.0278316   0.0692897             0.992455       0.977947                  9.31424       
6           0.0196535   0.0714647             0.99371        0.977999                  10.7899       
7           0.012005    0.0664562             0.996595       0.979659                  12.2408       
8           0.00710496  0.067457              0.998197       0.980159                  13.6929       
9           0.00783728  0.0745965             0.99793        0.981014                  15.1432       
10          0.00743822  0.0885449             0.99793        0.977436                  16.5919       
11          0.0060741   0.0673104             0.99808        0.984128                  18.0479       
12          0.0103096   0.0830764             0.99586        0.980354                  19.5022       
13          0.00647405  0.0704965             0.99793        0.982066                  20.933        
14          0.00735339  0.07865               0.997663       0.982445                  22.3739       
15          0.00404976  0.0789971             0.998665       0.981307                  23.8094       
16          0.00673548  0.0855032             0.99813        0.982456                  25.2593       
17          0.00897517  0.0938616             0.997352       0.980406                  26.7446       
18          0.00623781  0.0982162             0.997129       0.980767                  28.1852       
19          0.005356    0.0987159             0.99813        0.980612                  29.6471       
20          0.00529391  0.0891415             0.998264       0.9816                    31.0778       
```

I fixed it.